### PR TITLE
git autosetremote

### DIFF
--- a/users/packages/git.nix
+++ b/users/packages/git.nix
@@ -14,6 +14,7 @@ _:
         pu = "push origin";
         pl = "pull origin";
       };
+      push.autoSetupRemote = true;
     };
     ignores = [
       ".idea/"


### PR DESCRIPTION
This pull request makes a minor configuration change to the Git settings. The main update is enabling automatic setup of the remote tracking branch when pushing for the first time.

* Added `push.autoSetupRemote = true` to the Git configuration to streamline pushing new branches by automatically setting up the remote tracking branch.