### PR TITLE
add NixOS26.05

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -111,16 +111,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1779506708,
-        "narHash": "sha256-QOD/CNm196nCJRheux/URi4/HE66fthdOMqCJoPP1Y0=",
+        "lastModified": 1779726825,
+        "narHash": "sha256-RUkMrREjKDQrA+dA9+xZviGAxM5W1aVdyOr/bSYpHrE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "3ee51fbdac8c8bdfe1e7e1fcaba6520a563f394f",
+        "rev": "b179bde238977f7d4454fc770b1a727eaf55111c",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "ref": "release-25.11",
+        "ref": "release-26.05",
         "repo": "home-manager",
         "type": "github"
       }
@@ -660,32 +660,32 @@
         ]
       },
       "locked": {
-        "lastModified": 1772129556,
-        "narHash": "sha256-Utk0zd8STPsUJPyjabhzPc5BpPodLTXrwkpXBHYnpeg=",
+        "lastModified": 1779036909,
+        "narHash": "sha256-zXcwYQGCT6pzinK+1dBB2ekTVtfxGZAapb3Evdcu4fY=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "ebec37af18215214173c98cf6356d0aca24a2585",
+        "rev": "56c666e108467d87d13508936aade6d567f2a501",
         "type": "github"
       },
       "original": {
         "owner": "LnL7",
-        "ref": "nix-darwin-25.11",
+        "ref": "nix-darwin-26.05",
         "repo": "nix-darwin",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1779673555,
-        "narHash": "sha256-IZlTNZIKJNu1v7DAOpAxpBHMMLEaTZmc60tZ2SWz3i4=",
+        "lastModified": 1780230651,
+        "narHash": "sha256-LGbZ1K2+/aENomZ8Kn1NKoakYVkKryqfqEDUKFMz4Js=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e8b7777533400ecaf7236f57ae2e9eee65175cb4",
+        "rev": "4ebfbb559f873d6734ffdeac87f0b4b02fe31645",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "release-25.11",
+        "ref": "release-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,17 +1,17 @@
 {
   description = "kashu's Nix Configuration with flakes";
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/release-25.11";
+    nixpkgs.url = "github:NixOS/nixpkgs/release-26.05";
 
     nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
 
     nix-darwin = {
-      url = "github:LnL7/nix-darwin/nix-darwin-25.11";
+      url = "github:LnL7/nix-darwin/nix-darwin-26.05";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
     home-manager = {
-      url = "github:nix-community/home-manager/release-25.11";
+      url = "github:nix-community/home-manager/release-26.05";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 

--- a/hosts/l390-laptop/l390-laptop-configuration.nix
+++ b/hosts/l390-laptop/l390-laptop-configuration.nix
@@ -181,9 +181,6 @@
   hardware.bluetooth.enable = true;
   services.blueman.enable = true;
 
-  # Brightness
-  programs.light.enable = true;
-
   # Input devices
   hardware.trackpoint = {
     enable = true;
@@ -301,6 +298,7 @@
     unzip
     traceroute
     dig
+    brightnessctl
   ];
 
   # Nix-ld

--- a/hosts/nixos-desktop/nixos-desktop-configuration.nix
+++ b/hosts/nixos-desktop/nixos-desktop-configuration.nix
@@ -184,8 +184,10 @@
   # Enable the OpenSSH daemon.
   services.openssh = {
     enable = true;
-    permitRootLogin = "no";
-    passwordAuthentication = false;
+    settings = {
+      PermitRootLogin = "no";
+      PasswordAuthentication = false;
+    };
     ports = [ 56756 ];
   };
 

--- a/users/l390-laptop.nix
+++ b/users/l390-laptop.nix
@@ -131,8 +131,8 @@
           #  "${modifier}+Shift+q" = "kill";
           # Custom binding
           "${modifier}+g" = "exec google-chrome-stable";
-          "XF86MonBrightnessUp" = "exec light -A 1";
-          "XF86MonBrightnessDown" = "exec light -U 1";
+          "XF86MonBrightnessUp" = "exec brightnessctl set +1%";
+          "XF86MonBrightnessDown" = "exec brightnessctl set 1%-";
           "Print" = "exec flameshot full";
           "Shift+Print" = "exec flameshot gui";
         };

--- a/users/packages/hyprland/hyprland.nix
+++ b/users/packages/hyprland/hyprland.nix
@@ -24,6 +24,7 @@
 
   wayland.windowManager.hyprland = {
     enable = true;
+    configType = "hyprlang";
     systemd.enable = false;
   };
 

--- a/users/packages/nvim.nix
+++ b/users/packages/nvim.nix
@@ -19,7 +19,9 @@
       inoremap <silent> jj <ESC>
       inoremap <silent><expr> <CR> coc#pum#visible() ? coc#pum#confirm() : "\<CR>"
     '';
-    extraLuaConfig = ''
+    initLua = ''
+      local builtin = require('telescope.builtin')
+
       vim.keymap.set('n', '<C-n>', ':Neotree filesystem reveal left<CR>')
       vim.keymap.set('n', '<leader>ff', builtin.find_files, { desc = 'Telescope find files' })
       vim.keymap.set('n', '<leader>fg', builtin.live_grep, { desc = 'Telescope live grep' })
@@ -27,6 +29,8 @@
       vim.keymap.set('n', '<leader>fh', builtin.help_tags, { desc = 'Telescope help tags' })
     '';
     withNodeJs = true;
+    withPython3 = true;
+    withRuby = true;
     coc = {
       enable = true;
       pluginConfig = ''
@@ -221,7 +225,6 @@
       }
       barbar-nvim
 
-      coc-tsserver # TypeScript LSP
       coc-rust-analyzer # Rust LSP
       coc-yaml
       coc-toml
@@ -235,7 +238,6 @@
       coc-jest
       coc-html
       coc-git
-      coc-go
       coc-eslint
       coc-emmet
       coc-docker

--- a/users/packages/ssh.nix
+++ b/users/packages/ssh.nix
@@ -2,59 +2,59 @@ _: {
   programs.ssh = {
     enable = true;
     enableDefaultConfig = false;
-    matchBlocks."*" = {
-      compression = true;
-      serverAliveInterval = 10;
+    settings."*" = {
+      Compression = true;
+      ServerAliveInterval = 10;
     };
-    matchBlocks."github.com" = {
-      hostname = "github.com";
-      identitiesOnly = true;
-      identityFile = "~/.ssh/github";
-      user = "git";
+    settings."github.com" = {
+      HostName = "github.com";
+      IdentitiesOnly = true;
+      IdentityFile = "~/.ssh/github";
+      User = "git";
     };
-    matchBlocks."git.bgp.ne.jp" = {
-      hostname = "git.bgp.ne.jp";
-      identitiesOnly = true;
-      identityFile = "~/.ssh/github";
-      user = "git";
+    settings."git.bgp.ne.jp" = {
+      HostName = "git.bgp.ne.jp";
+      IdentitiesOnly = true;
+      IdentityFile = "~/.ssh/github";
+      User = "git";
     };
-    matchBlocks."dev-nix" = {
-      hostname = "home.kashu.dev";
-      identityFile = "~/.ssh/dev-nix";
-      port = 56754;
-      user = "kashu";
+    settings."dev-nix" = {
+      HostName = "home.kashu.dev";
+      IdentityFile = "~/.ssh/dev-nix";
+      Port = 56754;
+      User = "kashu";
     };
-    matchBlocks."desktop" = {
-      hostname = "home.kashu.dev";
-      identityFile = "~/.ssh/dev-nix";
-      port = 56756;
-      user = "kashu";
+    settings."desktop" = {
+      HostName = "home.kashu.dev";
+      IdentityFile = "~/.ssh/dev-nix";
+      Port = 56756;
+      User = "kashu";
     };
-    matchBlocks."lab-pc" = {
-      hostname = "192.168.50.100";
-      identityFile = "~/.ssh/lab-pc";
-      user = "kashu";
-      proxyJump = "dev-nix";
+    settings."lab-pc" = {
+      HostName = "192.168.50.100";
+      IdentityFile = "~/.ssh/lab-pc";
+      User = "kashu";
+      ProxyJump = "dev-nix";
     };
-    matchBlocks."u-aizu" = {
-      hostname = "sshgate.u-aizu.ac.jp";
-      identityFile = "~/.ssh/u-aizu";
-      user = "m5301034";
+    settings."u-aizu" = {
+      HostName = "sshgate.u-aizu.ac.jp";
+      IdentityFile = "~/.ssh/u-aizu";
+      User = "m5301034";
     };
-    matchBlocks."linsv" = {
-      hostname = "linsv.u-aizu.ac.jp";
-      user = "m5301034";
-      identityFile = "~/.ssh/u-aizu";
-      proxyJump = "u-aizu";
+    settings."linsv" = {
+      HostName = "linsv.u-aizu.ac.jp";
+      User = "m5301034";
+      IdentityFile = "~/.ssh/u-aizu";
+      ProxyJump = "u-aizu";
     };
-    matchBlocks."llmsv" = {
-      hostname = "192.168.11.250";
-      identityFile = "~/.ssh/github";
+    settings."llmsv" = {
+      HostName = "192.168.11.250";
+      IdentityFile = "~/.ssh/github";
     };
-    matchBlocks."containerlab" = {
-      hostname = "172.16.10.110";
-      identityFile = "~/.ssh/github";
-      user = "kashu";
+    settings."containerlab" = {
+      HostName = "172.16.10.110";
+      IdentityFile = "~/.ssh/github";
+      User = "kashu";
     };
   };
 }


### PR DESCRIPTION
This pull request contains several updates across system configuration, package management, and user environment customization. The main themes are upgrading to newer NixOS releases, improving SSH and OpenSSH configuration consistency, switching brightness control utilities, and updating Neovim plugin and language support.

**System and Package Upgrades:**
- Upgraded `nixpkgs`, `nix-darwin`, and `home-manager` inputs to the `release-26.05` branch in `flake.nix` for newer package versions and features.

**Configuration Consistency and Security:**
- Refactored SSH client configuration in `ssh.nix` to use the `settings` attribute instead of `matchBlocks` for improved clarity and maintainability.
- Updated OpenSSH server configuration in `nixos-desktop-configuration.nix` to use the `settings` attribute, aligning with current NixOS best practices.

**User Environment and Utilities:**
- Replaced the `light` brightness utility with `brightnessctl` for brightness control on the L390 laptop, updating both the installed packages and keybindings accordingly. [[1]](diffhunk://#diff-bb8cb78f7b26748896b69b4449fd56fbd1781329f589c92e96569bc174b163bdL184-L186) [[2]](diffhunk://#diff-bb8cb78f7b26748896b69b4449fd56fbd1781329f589c92e96569bc174b163bdR301) [[3]](diffhunk://#diff-2e4d0137fc16322864d5d00d0ebf793678c0d8ac992a8fb277189822a1ce126fL134-R135)
- Enabled `withPython3` and `withRuby` support in Neovim, and migrated from `extraLuaConfig` to `initLua` for improved plugin configuration. Also, removed unused or problematic plugins (`coc-tsserver`, `coc-go`). [[1]](diffhunk://#diff-8897687a3c8cbe22192ce058fcbe51b623d50710c31ae1dd1fc5446ce28ae58bL22-R33) [[2]](diffhunk://#diff-8897687a3c8cbe22192ce058fcbe51b623d50710c31ae1dd1fc5446ce28ae58bL224) [[3]](diffhunk://#diff-8897687a3c8cbe22192ce058fcbe51b623d50710c31ae1dd1fc5446ce28ae58bL238)

**Wayland Window Manager:**
- Explicitly set `configType = "hyprlang"` for Hyprland configuration to ensure correct parsing and behavior.