### PR TITLE
use ryoppippi nix claude code

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -653,6 +653,24 @@
         "type": "github"
       }
     },
+    "nix-claude-code": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1781146851,
+        "narHash": "sha256-+AWRZLbkDhfB2ibS4Ps7sarbxcOowrZlTjXjW9Wc4Nw=",
+        "owner": "ryoppippi",
+        "repo": "nix-claude-code",
+        "rev": "34b981b6740624b595f8da0ab8af2ad38f516ad6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ryoppippi",
+        "repo": "nix-claude-code",
+        "type": "github"
+      }
+    },
     "nix-darwin": {
       "inputs": {
         "nixpkgs": [
@@ -676,16 +694,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1779673555,
-        "narHash": "sha256-IZlTNZIKJNu1v7DAOpAxpBHMMLEaTZmc60tZ2SWz3i4=",
+        "lastModified": 1779560665,
+        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e8b7777533400ecaf7236f57ae2e9eee65175cb4",
+        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "release-25.11",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -702,6 +720,22 @@
       "original": {
         "owner": "NixOS",
         "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1779673555,
+        "narHash": "sha256-IZlTNZIKJNu1v7DAOpAxpBHMMLEaTZmc60tZ2SWz3i4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e8b7777533400ecaf7236f57ae2e9eee65175cb4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "release-25.11",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -734,8 +768,9 @@
         "home-manager": "home-manager",
         "hyprland": "hyprland",
         "hyprpaper": "hyprpaper",
+        "nix-claude-code": "nix-claude-code",
         "nix-darwin": "nix-darwin",
-        "nixpkgs": "nixpkgs",
+        "nixpkgs": "nixpkgs_2",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "rose-pine-hyprcursor": "rose-pine-hyprcursor",
         "systems": "systems_3",

--- a/flake.nix
+++ b/flake.nix
@@ -37,6 +37,8 @@
       inputs.hyprlang.follows = "hyprland/hyprlang";
     };
 
+    nix-claude-code.url = "github:ryoppippi/nix-claude-code";
+
     systems.url = "github:nix-systems/default";
   };
 
@@ -50,6 +52,7 @@
       home-manager,
       treefmt-nix,
       systems,
+      nix-claude-code,
       ...
     }:
     let
@@ -84,6 +87,7 @@
               home-manager.extraSpecialArgs = { inherit inputs; };
             }
             unstable-overlays
+            { nixpkgs.overlays = [ nix-claude-code.overlays.default ]; }
           ];
         };
 
@@ -114,6 +118,7 @@
               home-manager.extraSpecialArgs = { inherit inputs; };
             }
             unstable-overlays
+            { nixpkgs.overlays = [ nix-claude-code.overlays.default ]; }
           ];
         };
 
@@ -144,6 +149,7 @@
               home-manager.extraSpecialArgs = { inherit inputs; };
             }
             unstable-overlays
+            { nixpkgs.overlays = [ nix-claude-code.overlays.default ]; }
           ];
         };
 
@@ -175,6 +181,7 @@
               home-manager.extraSpecialArgs = { inherit inputs; };
             }
             unstable-overlays
+            { nixpkgs.overlays = [ nix-claude-code.overlays.default ]; }
           ];
         };
 

--- a/users/packages/common.nix
+++ b/users/packages/common.nix
@@ -25,10 +25,10 @@
       peco
       nmap
       ripgrep
+      claude-code
     ])
     ++ (with pkgs.unstable; [
       gemini-cli
-      claude-code
       codex
       opencode
     ]);


### PR DESCRIPTION
This pull request updates the Nix flake configuration to add support for the `nix-claude-code` overlay and adjusts how the `claude-code` package is included. The main focus is on integrating the new overlay and ensuring the package is sourced from the correct channel.

**Nix flake overlay integration:**

* Added `nix-claude-code` as a new input in the `flake.nix` inputs, referencing the GitHub repository.
* Included `nix-claude-code` in the list of inputs passed to the flake outputs function.
* Applied the `nix-claude-code` overlay to `nixpkgs` in all relevant system configurations, ensuring the overlay is active for package resolution. [[1]](diffhunk://#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0R90) [[2]](diffhunk://#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0R121) [[3]](diffhunk://#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0R152) [[4]](diffhunk://#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0R184)

**Package source adjustment:**

* Removed `claude-code` from the `unstable` package set in `users/packages/common.nix`, so it is now only sourced via the overlay, preventing duplication or conflicts.